### PR TITLE
0.8.0.0-beta (2015-04-28) - Beta + KSP 1.0 updates

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -12,14 +12,14 @@
 	"VERSION" :
 	{
 		"MAJOR" : 0,
-		"MINOR" : 7,
+		"MINOR" : 8,
 		"PATCH" : 0,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :
 	{
-		"MAJOR" : 0,
-		"MINOR" : 9,
+		"MAJOR" : 1,
+		"MINOR" : 0,
 		"PATCH" : 0
 	},
 	"KSP_VERSION_MIN" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,13 @@
+0.8 (2015-04-28) - Beta + KSP 1.0 updates
+ - Corrected Xenon options for Fuel Switcher.
+ - KSP 1.0 fixes, including but not limited to:
+    - Costs, max temps, and tech tree assignments of all fuel tanks
+    - Mass adjustments on 0.625m and 3.75m tanks
+    - Capacity adjustments on tanks close to Oscar-B
+    - Fixed bottom attachment nodes
+    - Added attachment profile settings
+    - Increased scale of "triangular" tanks by 25% to make them align nicely with the small cubes.
+
 0.7.1 (2015-03-25) - Beta
  - Corrected fuel capacity of the FL-T50 fuel tank.
 

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -12,14 +12,14 @@
 	"VERSION" :
 	{
 		"MAJOR" : 0,
-		"MINOR" : 7,
+		"MINOR" : 8,
 		"PATCH" : 0,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :
 	{
-		"MAJOR" : 0,
-		"MINOR" : 9,
+		"MAJOR" : 1,
+		"MINOR" : 0,
 		"PATCH" : 0
 	},
 	"KSP_VERSION_MIN" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus_FuelSwitch.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus_FuelSwitch.cfg
@@ -100,7 +100,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;LiquidFuel;Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;LiquidFuel;Oxidizer;XenonGas
 		resourceAmounts = 45,55;90;110;875
 		basePartMass = 0.0625
 		displayCurrentTankCost = false
@@ -116,7 +116,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 27,33;665
 		basePartMass = 0.0475
 		displayCurrentTankCost = false
@@ -132,7 +132,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 13.5,16.5;385
 		basePartMass = 0.0275
 		displayCurrentTankCost = false
@@ -148,7 +148,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 2.7,3.3;95
 		basePartMass = 0.007
 		displayCurrentTankCost = false
@@ -164,7 +164,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 22.5,27.5;2800
 		basePartMass = 0.125
 		displayCurrentTankCost = false
@@ -180,7 +180,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 36,44;980
 		basePartMass = 0.07
 		displayCurrentTankCost = false
@@ -196,7 +196,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 8.1,9.9;210
 		basePartMass = 0.015
 		displayCurrentTankCost = false
@@ -212,7 +212,7 @@
 	{
 
 		name = FSfuelSwitch
-		resourceNames = LiquidFuel,Oxidizer;Xenon
+		resourceNames = LiquidFuel,Oxidizer;XenonGas
 		resourceAmounts = 2.7,3.3;140
 		basePartMass = 0.01
 		displayCurrentTankCost = false

--- a/GameData/NecroBones/FuelTanksPlus/Probe/TPtankCube00500.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/TPtankCube00500.cfg
@@ -12,10 +12,10 @@ scale = 1.0
 rescaleFactor = 0.97
 
 node_stack_top = 0.0, 0.25, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.25, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.25, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.25, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = propulsionSystems
 entryCost = 1600
 cost = 150
 category = FuelTank
@@ -34,9 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 RESOURCE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Probe/TPtankCube00750.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/TPtankCube00750.cfg
@@ -12,10 +12,10 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.375, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.375, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.375, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.375, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = propulsionSystems
 entryCost = 1600
 cost = 400
 category = FuelTank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Probe/TPtankCube01250.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/TPtankCube01250.cfg
@@ -12,10 +12,10 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.625, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.625, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.625, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.625, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = propulsionSystems
 entryCost = 1600
 cost = 1000
 category = FuelTank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Probe/TPtankTri01-LFO.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/TPtankTri01-LFO.cfg
@@ -9,12 +9,12 @@ MODEL {
 	scale = 1.0, 1.0, 1.0
 }
 scale = 1.0
-rescaleFactor = 1.0
+rescaleFactor = 1.25
 
 node_stack_top = 0.0, 0.1925, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.1925, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.1925, 0.0, 0.0, -1.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = propulsionSystems
 entryCost = 1600
 cost = 200
 category = FuelTank
@@ -33,8 +33,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Probe/TPtankTri02-Xenon.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/TPtankTri02-Xenon.cfg
@@ -9,10 +9,10 @@ MODEL {
 	scale = 1.0, 1.0, 1.0
 }
 scale = 1.0
-rescaleFactor = 1.0
+rescaleFactor = 1.25
 
 node_stack_top = 0.0, 0.1925, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.1925, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.1925, 0.0, 0.0, -1.0, 0.0, 0
 
 TechRequired = ionPropulsion
 entryCost = 16000
@@ -33,8 +33,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL00175-Grey.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL00175-Grey.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.0875, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.0875, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.0875, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.3125, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = precisionPropulsion
 entryCost = 4500
-cost = 150
+cost = 100
 category = FuelTank
 subcategory = 0
 title = Oscar-A 0.625m Fuel Tank
@@ -26,7 +26,7 @@ description = Small scale fuel storage for satellites, probes, and other small v
 
 attachRules = 1,1,1,1,0
 
-mass = 0.007
+mass = 0.01
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.15
@@ -34,22 +34,22 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE
 {
  name = LiquidFuel
- amount = 2.7
- maxAmount = 2.7
+ amount = 4.05
+ maxAmount = 4.05
 }
 
 RESOURCE
 {
  name = Oxidizer
- amount = 3.3
- maxAmount = 3.3
+ amount = 4.95
+ maxAmount = 4.95
 }
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL00700-Grey.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL00700-Grey.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.35, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.35, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.35, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.3125, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = precisionPropulsion
 entryCost = 2200
-cost = 350
+cost = 150
 category = FuelTank
 subcategory = 0
 title = Oscar-C 0.625m Fuel Tank
@@ -26,7 +26,7 @@ description = Small scale fuel storage for satellites, probes, and other small v
 
 attachRules = 1,1,1,1,0
 
-mass = 0.0275
+mass = 0.035
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.15
@@ -34,22 +34,22 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE
 {
  name = LiquidFuel
- amount = 13.5
- maxAmount = 13.5
+ amount = 16.875
+ maxAmount = 16.875
 }
 
 RESOURCE
 {
  name = Oxidizer
- amount = 16.5
- maxAmount = 16.5
+ amount = 20.625
+ maxAmount = 20.625
 }
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01350-Grey.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01350-Grey.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.675, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.675, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.675, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.3125, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = precisionPropulsion
 entryCost = 1800
-cost = 500
+cost = 350
 category = FuelTank
 subcategory = 0
 title = Oscar-D 0.625m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01875-Black.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01875-Black.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.9375, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.3125, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = precisionPropulsion
 entryCost = 1600
-cost = 600
+cost = 500
 category = FuelTank
 subcategory = 0
 title = Probodobodyne 0.625m Vanguard-100 Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01875-Grey.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01875-Grey.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.9375, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.3125, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = precisionPropulsion
 entryCost = 1600
-cost = 600
+cost = 500
 category = FuelTank
 subcategory = 0
 title = Oscar-100 0.625m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01875-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/TPtank0mL01875-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.9375, 0.0, 0.0, 1.0, 0.0, 0
-node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, 1.0, 0.0, 0
+node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, -1.0, 0.0, 0
 node_attach = 0.3125, 0.0, 0.0, 1.0, 0.0, 0.0, 0
 
-TechRequired = precisionEngineering
+TechRequired = precisionPropulsion
 entryCost = 1600
-cost = 600
+cost = 500
 category = FuelTank
 subcategory = 0
 title = Probodobodyne 0.625m Juno-100 Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size0, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL00313-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL00313-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.15625, 0.0, 0.0, 1.0, 0.0, 1
-node_stack_bottom = 0.0, -0.15625, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -0.15625, 0.0, 0.0, -1.0, 0.0, 1
 node_attach = 0.625, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 
 TechRequired = basicRocketry
-entryCost = 500
-cost = 200
+entryCost = 800
+cost = 100
 category = FuelTank
 subcategory = 0
 title = FL-T50 Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 70
 breakingTorque = 70
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size1, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL05625-Checkered.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL05625-Checkered.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 2.8125, 0.0, 0.0, 1.0, 0.0, 1
-node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, -1.0, 0.0, 1
 node_attach = 0.625, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 
-TechRequired = advRocketry
+TechRequired = fuelSystems
 entryCost = 4800
-cost = 2400
+cost = 1200
 category = FuelTank
 subcategory = 0
 title = FL-T1200-Redstone Fuel Tank
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 75
 breakingTorque = 75
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size1, srf
 
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL05625-Green.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL05625-Green.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 2.8125, 0.0, 0.0, 1.0, 0.0, 1
-node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, -1.0, 0.0, 1
 node_attach = 0.625, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 
-TechRequired = heavyRocketry
+TechRequired = fuelSystems
 entryCost = 4800
-cost = 2400
+cost = 1200
 category = FuelTank
 subcategory = 0
 title = FL-T1200-Soyuz Fuel Tank
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 75
 breakingTorque = 75
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size1, srf
 
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL05625-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL05625-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 2.8125, 0.0, 0.0, 1.0, 0.0, 1
-node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, -1.0, 0.0, 1
 node_attach = 0.625, 0.0, 0.0, 1.0, 0.0, 0.0, 1
 
-TechRequired = advRocketry
+TechRequired = fuelSystems
 entryCost = 4800
-cost = 2400
+cost = 1200
 category = FuelTank
 subcategory = 0
 title = FL-T1200-Vega Fuel Tank
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 75
 breakingTorque = 75
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size1, srf
 
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPcone2m-Orange.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPcone2m-Orange.cfg
@@ -19,7 +19,7 @@ rescaleFactor = 1.0
 
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-node_stack_bottom = 0.0, -0.5, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
 
 
 
@@ -27,9 +27,9 @@ node_stack_bottom = 0.0, -0.5, 0.0, 0.0, 1.0, 0.0, 2
 
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 6400
-cost = 3200
+cost = 1500
 category = FuelTank
 subcategory = 0
 title = Rockomax Jumbo-16 2.5m Nose Tank
@@ -45,8 +45,8 @@ maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 10
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size2
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPcone2m-Red.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPcone2m-Red.cfg
@@ -17,7 +17,7 @@ rescaleFactor = 1.0
 
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-node_stack_bottom = 0.0, -0.5, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
 
 
 
@@ -25,9 +25,9 @@ node_stack_bottom = 0.0, -0.5, 0.0, 0.0, 1.0, 0.0, 2
 
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 6400
-cost = 3200
+cost = 1500
 category = FuelTank
 subcategory = 0
 title = Rockomax Atlas-16 2.5m Nose Tank
@@ -43,8 +43,8 @@ maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 10
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size2
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPcone2m-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPcone2m-White.cfg
@@ -17,7 +17,7 @@ rescaleFactor = 1.0
 
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-node_stack_bottom = 0.0, -0.5, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
 
 
 
@@ -25,9 +25,9 @@ node_stack_bottom = 0.0, -0.5, 0.0, 0.0, 1.0, 0.0, 2
 
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 6400
-cost = 3200
+cost = 1500
 category = FuelTank
 subcategory = 0
 title = Rockomax Antares-16 2.5m Nose Tank
@@ -43,8 +43,8 @@ maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 10
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size2
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPdome2m-Orange.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPdome2m-Orange.cfg
@@ -20,7 +20,7 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1
 
 
 
@@ -28,9 +28,9 @@ node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 4800
-cost = 1600
+cost = 800
 category = FuelTank
 subcategory = 0
 title = Rockomax Jumbo-8 2.5m Bottom Dome
@@ -46,8 +46,8 @@ maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 15
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size2
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPdome2m-Red.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPdome2m-Red.cfg
@@ -18,7 +18,7 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1
 
 
 
@@ -26,9 +26,9 @@ node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 4800
-cost = 1600
+cost = 800
 category = FuelTank
 subcategory = 0
 title = Rockomax Atlas-8 2.5m Bottom Dome
@@ -44,8 +44,8 @@ maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 15
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size2
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPdome2m-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPdome2m-White.cfg
@@ -18,7 +18,7 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1
 
 
 
@@ -26,9 +26,9 @@ node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 4800
-cost = 1600
+cost = 800
 category = FuelTank
 subcategory = 0
 title = Rockomax Antares-8 2.5m Bottom Dome
@@ -44,8 +44,8 @@ maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 15
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size2
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL00469-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL00469-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.234375, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -0.234375, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -0.234375, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = fuelSystems
 entryCost = 2600
-cost = 800
+cost = 400
 category = FuelTank
 subcategory = 0
 title = Rockomax X200-4-Antares 2.5m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 190
 breakingTorque = 190
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL05625-Orange.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL05625-Orange.cfg
@@ -14,12 +14,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 2.8125, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 19200
-cost = 9600
+cost = 4500
 category = FuelTank
 subcategory = 0
 title = Rockomax Jumbo-48 2.5m Fuel Tank
@@ -36,8 +36,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 250
 breakingTorque = 250
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 RESOURCE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL05625-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL05625-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 2.8125, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = advFuelSystems
 entryCost = 19200
-cost = 9600
+cost = 4500
 category = FuelTank
 subcategory = 0
 title = Rockomax X200-48-Antares 2.5m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 250
 breakingTorque = 250
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-Blue.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-Blue.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = largeVolumeContainment
 entryCost = 24200
-cost = 19200
+cost = 9000
 category = FuelTank
 subcategory = 0
 title = Rockomax X200-96-Delta 2.5m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 250
 breakingTorque = 250
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-Orange.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-Orange.cfg
@@ -14,12 +14,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = largeVolumeContainment
 entryCost = 24200
-cost = 19200
+cost = 9000
 category = FuelTank
 subcategory = 0
 title = Rockomax Jumbo-96 2.5m Fuel Tank
@@ -36,8 +36,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 250
 breakingTorque = 250
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-Red.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-Red.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = largeVolumeContainment
 entryCost = 24200
-cost = 19200
+cost = 9000
 category = FuelTank
 subcategory = 0
 title = Rockomax X200-96-Atlas 2.5m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 250
 breakingTorque = 250
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL11250-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 2
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 2
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 2
 node_attach = 1.25, 0.0, 0.0, 1.0, 0.0, 0.0, 2
 
-TechRequired = heavierRocketry
+TechRequired = largeVolumeContainment
 entryCost = 24200
-cost = 19200
+cost = 9000
 category = FuelTank
 subcategory = 0
 title = Rockomax X200-96-Antares 2.5m Fuel Tank
@@ -34,8 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 250
 breakingTorque = 250
-maxTemp = 2900
-
+maxTemp = 2000
+bulkheadProfiles = size2, srf
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPcone3m-Silver.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPcone3m-Silver.cfg
@@ -17,7 +17,7 @@ rescaleFactor = 1.0
 
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 3
 
 
 
@@ -27,7 +27,7 @@ node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 3
 // --- editor parameters ---
 TechRequired = veryHeavyRocketry
 entryCost = 6400
-cost = 3200
+cost = 1600
 category = FuelTank
 subcategory = 0
 title = Kerbodyne S3-2400-Titan Nose Tank
@@ -37,14 +37,14 @@ description = A large aerodynamic, fuel-filled cone for covering the top of larg
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 1.5
+mass = 1.35
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 10
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size3
 
 
 RESOURCE

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPcone3m-Tan.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPcone3m-Tan.cfg
@@ -17,7 +17,7 @@ rescaleFactor = 1.0
 
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 3
 
 
 
@@ -25,9 +25,9 @@ node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 3
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = largeVolumeContainment
 entryCost = 6400
-cost = 3200
+cost = 1600
 category = FuelTank
 subcategory = 0
 title = Kerbodyne S3-2400-Ariane Nose Tank
@@ -37,13 +37,14 @@ description = A large aerodynamic, fuel-filled cone for covering the top of larg
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 1.5
+mass = 1.35
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 10
-maxTemp = 3400
+maxTemp = 2000
+bulkheadProfiles = size3
 
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPcone3m-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPcone3m-White.cfg
@@ -17,7 +17,7 @@ rescaleFactor = 1.0
 
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 3
 
 
 
@@ -25,9 +25,9 @@ node_stack_bottom = 0.0, -0.75, 0.0, 0.0, 1.0, 0.0, 3
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = largeVolumeContainment
 entryCost = 6400
-cost = 3200
+cost = 1600
 category = FuelTank
 subcategory = 0
 title = Kerbodyne S3-2400-Falcon Nose Tank
@@ -37,14 +37,14 @@ description = A large aerodynamic, fuel-filled cone for covering the top of larg
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 1.5
+mass = 1.35
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 10
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size3
 
 RESOURCE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPdome3m-Silver.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPdome3m-Silver.cfg
@@ -18,7 +18,7 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -1.14, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -1.14, 0.0, 0.0, -1.0, 0.0, 1
 
 
 
@@ -26,9 +26,9 @@ node_stack_bottom = 0.0, -1.14, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = largeVolumeContainment
 entryCost = 4800
-cost = 1600
+cost = 800
 category = FuelTank
 subcategory = 0
 title = Kerbodyne S3-1200-Titan Dome Tank
@@ -38,14 +38,14 @@ description = A domed tank for the bottom of external tank assemblies. Manufactu
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 0.75
+mass = 0.675
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 15
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size3, size1
 
 RESOURCE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPdome3m-Tan.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPdome3m-Tan.cfg
@@ -18,7 +18,7 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -1.14, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -1.14, 0.0, 0.0, -1.0, 0.0, 1
 
 
 
@@ -26,9 +26,9 @@ node_stack_bottom = 0.0, -1.14, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = largeVolumeContainment
 entryCost = 4800
-cost = 1600
+cost = 800
 category = FuelTank
 subcategory = 0
 title = Kerbodyne S3-1200-Ariane Dome Tank
@@ -38,14 +38,14 @@ description = A domed tank for the bottom of external tank assemblies. Manufactu
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 0.75
+mass = 0.675
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 15
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size3, size1
 
 RESOURCE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPdome3m-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPdome3m-White.cfg
@@ -18,7 +18,7 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -1.14, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_bottom = 0.0, -1.14, 0.0, 0.0, -1.0, 0.0, 1
 
 
 
@@ -26,9 +26,9 @@ node_stack_bottom = 0.0, -1.14, 0.0, 0.0, 1.0, 0.0, 1
 
 
 // --- editor parameters ---
-TechRequired = veryHeavyRocketry
+TechRequired = largeVolumeContainment
 entryCost = 4800
-cost = 1600
+cost = 800
 category = FuelTank
 subcategory = 0
 title = Kerbodyne S3-1200-Falcon Dome Tank
@@ -38,14 +38,14 @@ description = A domed tank for the bottom of external tank assemblies. Manufactu
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---
-mass = 0.75
+mass = 0.675
 dragModelType = default
 maximum_drag = 0.1
 minimum_drag = 0.1
 angularDrag = 0.5
 crashTolerance = 15
-maxTemp = 3400
-
+maxTemp = 2000
+bulkheadProfiles = size3, size1
 
 RESOURCE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL00938-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL00938-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 0.46875, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -0.46875, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -0.46875, 0.0, 0.0, -1.0, 0.0, 3
 node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-TechRequired = veryHeavyRocketry
+TechRequired = largeVolumeContainment
 entryCost = 7200
-cost = 3600
+cost = 1625
 category = Propulsion
 subcategory = 0
 title = Kerbodyne S3-1800-Falcon Tank
@@ -26,7 +26,7 @@ description = A super-heavy fuel tank, intended for the largest boosters you wil
 
 attachRules = 1,1,1,1,0
 
-mass = 1.25
+mass = 1.125
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.3
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size3, srf
 
 MODULE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL05625-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL05625-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 2.8125, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -2.8125, 0.0, 0.0, -1.0, 0.0, 3
 node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-TechRequired = veryHeavyRocketry
+TechRequired = highPerformanceFuelSystems
 entryCost = 34200
-cost = 17100
+cost = 9750
 category = Propulsion
 subcategory = 0
 title = Kerbodyne S3-10800-Falcon Tank
@@ -26,7 +26,7 @@ description = A super-heavy fuel tank, intended for the largest boosters you wil
 
 attachRules = 1,1,1,1,0
 
-mass = 7.5
+mass = 6.75
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.3
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 550
 breakingTorque = 550
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size3, srf
 
 MODULE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL11250-Silver.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL11250-Silver.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 3
 node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-TechRequired = veryHeavyRocketry
+TechRequired = highPerformanceFuelSystems
 entryCost = 46600
-cost = 34200
+cost = 19500
 category = Propulsion
 subcategory = 0
 title = Kerbodyne S3-21600-Titan Tank
@@ -26,7 +26,7 @@ description = A super-heavy fuel tank, intended for the largest boosters you wil
 
 attachRules = 1,1,1,1,0
 
-mass = 15
+mass = 13.5
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.3
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 600
 breakingTorque = 600
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size3, srf
 
 MODULE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL11250-Tan.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL11250-Tan.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 3
 node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-TechRequired = veryHeavyRocketry
+TechRequired = highPerformanceFuelSystems
 entryCost = 46600
-cost = 34200
+cost = 19500
 category = Propulsion
 subcategory = 0
 title = Kerbodyne S3-21600-Ariane Tank
@@ -26,7 +26,7 @@ description = A super-heavy fuel tank, intended for the largest boosters you wil
 
 attachRules = 1,1,1,1,0
 
-mass = 15
+mass = 13.5
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.3
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 600
 breakingTorque = 600
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size3, srf
 
 MODULE
 {

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL11250-White.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL11250-White.cfg
@@ -12,12 +12,12 @@ scale = 1.0
 rescaleFactor = 1.0
 
 node_stack_top = 0.0, 5.625, 0.0, 0.0, 1.0, 0.0, 3
-node_stack_bottom = 0.0, -5.625, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -5.625, 0.0, 0.0, -1.0, 0.0, 3
 node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-TechRequired = veryHeavyRocketry
+TechRequired = highPerformanceFuelSystems
 entryCost = 46600
-cost = 34200
+cost = 19500
 category = Propulsion
 subcategory = 0
 title = Kerbodyne S3-21600-Falcon Tank
@@ -26,7 +26,7 @@ description = A super-heavy fuel tank, intended for the largest boosters you wil
 
 attachRules = 1,1,1,1,0
 
-mass = 15
+mass = 13.5
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.3
@@ -34,7 +34,8 @@ angularDrag = 2
 crashTolerance = 6
 breakingForce = 600
 breakingTorque = 600
-maxTemp = 2900
+maxTemp = 2000
+bulkheadProfiles = size3, srf
 
 MODULE
 {

--- a/GameData/NecroBones/FuelTanksPlus/changelog.md
+++ b/GameData/NecroBones/FuelTanksPlus/changelog.md
@@ -446,7 +446,7 @@
 
 ---
 
-## 0.8 (2015-04-28) - Beta + KSP 1.0 updates
+## 0.8.0.0-beta (2015-04-28) - Beta + KSP 1.0 updates
 
 * Corrected Xenon options for Fuel Switcher.
 * KSP 1.0 fixes, including but not limited to:

--- a/json/ksp.json
+++ b/json/ksp.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "KSP",
  "labelColor": "black",
- "message": "0.9.0",
+ "message": "1.0.0",
  "color": "66ccff",
  "style": "plastic"
 }

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "0.7.0.0",
+ "message": "0.8.0.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 0.8.0.0-beta (2015-04-28) - Beta + KSP 1.0 updates

* Corrected Xenon options for Fuel Switcher.
* KSP 1.0 fixes, including but not limited to:
  * Costs, max temps, and tech tree assignments of all fuel tanks
  * Mass adjustments on 0.625m and 3.75m tanks
  * Capacity adjustments on tanks close to Oscar-B
  * Fixed bottom attachment nodes
  * Added attachment profile settings
  * Increased scale of "triangular" tanks by 25% to make them align nicely with the small cubes.
* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>
* closes #37 - 0.8 (2015-04-28) - Beta + KSP 1.0 updates
* updates #26 - Previous Releases

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>