### PR TITLE
1.2.1.0 (2015-09-14) - Tweaks

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 2,
-		"PATCH" : 0,
+		"PATCH" : 1,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,7 @@
+1.2.1 (2015-09-14) - Tweaks.
+ - Renamed the 0.625m red variant "Centaur", after the thrust vectoring tanks on the Centaur rocket boosters.
+ - Added missing TweakScale settings for 1.25m nose cones.
+
 1.2 (2015-08-31) - Minor update.
  - Corrected a texture alignment problem with the 0.625m tanks when using reduced texture resolution.
  - Added new red color option to the 0.625m tanks.

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 2,
-		"PATCH" : 0,
+		"PATCH" : 1,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus_TweakScale.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus_TweakScale.cfg
@@ -1,3 +1,12 @@
+@PART[TPcone1m*]:NEEDS[TweakScale]
+{
+	MODULE
+	{
+		name = TweakScale
+		type = stack
+		defaultScale = 1.25
+	}
+}
 @PART[TPcone2m*]:NEEDS[TweakScale]
 {
 	MODULE

--- a/GameData/NecroBones/FuelTanksPlus/Size0/000_TPtank0m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/000_TPtank0m_MM.cfg
@@ -5,7 +5,7 @@
 		name:NEEDS[!InterstellarFuelSwitch] = FSmeshSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarMeshSwitch
 		objects = TPtank0m-Grey;TPtank0m-White;TPtank0m-Checkered;TPtank0m-Black;TPtank0m-Red
-		objectDisplayNames = Oscar;Juno;Astrobee;Brant;Red
+		objectDisplayNames = Oscar;Juno;Astrobee;Brant;Centaur
 		affectColliders = false
 		buttonName = Next Variant
 		previousButtonName = Previous Variant

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "1.2.0.0",
+ "message": "1.2.1.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 1.2.1.0 (2015-09-14) - Tweaks

* Renamed the 0.625m red variant "Centaur", after the thrust vectoring tanks on the Centaur rocket boosters.
* Added missing TweakScale settings for 1.25m nose cones.
* closes #56 - 1.2.1 (2015-09-14) - Tweaks
* updates #26 - Previous Releases

---