### PR TITLE
1.8.1.0 (2016-04-24) - KSP 1.1 minor update

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 8,
-		"PATCH" : 0,
+		"PATCH" : 1,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.8.1 (2016-04-24) - KSP 1.1 minor update.
+ - Fix for fuel-switching to properly disable when something else is adding it (such as CryoEngines), relating to change in ModuleManager's logic.
+
 1.8 (2016-04-02) - KSP 1.1 minor update.
  - Added search tags.
  - Updated included copies of dependencies to 1.1 compatible versions.

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-README.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-README.txt
@@ -22,5 +22,5 @@ http://spacedock.info/mod/92/Fuel%20Tanks%20Plus
 Curse:
 http://www.curse.com/ksp-mods/kerbal/227356-fuel-tanks-plus
 
-This is being shared under the CC-NC-SA license:
+This is being shared under the CC-BY-NC-SA license:
 http://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 8,
-		"PATCH" : 0,
+		"PATCH" : 1,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/Patches/FuelTanksPlus_FuelSwitch.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Patches/FuelTanksPlus_FuelSwitch.cfg
@@ -1,5 +1,5 @@
 
-@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[Firespitter|InterstellarFuelSwitch]:NEEDS[!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "1.8.0.0",
+ "message": "1.8.1.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 1.8.1.0 (2016-04-24) - KSP 1.1 minor update

* Fix for fuel-switching to properly disable when something else is adding it (such as CryoEngines), relating to change in ModuleManager's logic.
* closes #65 - 1.8.1 (2016-04-24) - KSP 1.1 minor update
* updates #26 - Previous Releases

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>

---