### PR TITLE
1.8.2.0 (2016-04-28) - Mesh switching compatibility

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -1,5 +1,5 @@
 {
-	"NAME"		     : "FuelTanksPlus (FTP)",
+	"NAME"		     : "Fuel Tanks Plus (FTP)",
 	"URL"			 : "https://raw.githubusercontent.com/zer0Kerbal/FuelTanksPlus/master/FuelTanksPlus.version",
 	"DOWNLOAD"	     : "https://github.com/zer0Kerbal/FuelTanksPlus/releases/latest",
 	"CHANGE_LOG_URL" : "https://raw.githubusercontent.com/zer0Kerbal/FuelTanksPlus/master/changelog.md",
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 8,
-		"PATCH" : 1,
+		"PATCH" : 2,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.8.2 (2016-04-28) - Mesh switching compatibility
+ - Added support for B9PartSwitch. Firespitter and InterstellarFuelSwitch still work too, of course.
+
 1.8.1 (2016-04-24) - KSP 1.1 minor update.
  - Fix for fuel-switching to properly disable when something else is adding it (such as CryoEngines), relating to change in ModuleManager's logic.
 

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -1,5 +1,5 @@
 {
-	"NAME"		     : "FuelTanksPlus (FTP)",
+	"NAME"		     : "Fuel Tanks Plus (FTP)",
 	"URL"			 : "https://raw.githubusercontent.com/zer0Kerbal/FuelTanksPlus/master/FuelTanksPlus.version",
 	"DOWNLOAD"	     : "https://github.com/zer0Kerbal/FuelTanksPlus/releases/latest",
 	"CHANGE_LOG_URL" : "https://raw.githubusercontent.com/zer0Kerbal/FuelTanksPlus/master/changelog.md",
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 8,
-		"PATCH" : 1,
+		"PATCH" : 2,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/Probe/000_TPtankP_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/000_TPtankP_MM.cfg
@@ -1,4 +1,4 @@
-@PART[TPtankTri|TPtankCube???]
+@PART[TPtankTri|TPtankCube???]:NEEDS[Firespitter|InterstellarMeshSwitch&!B9PartSwitch]:AFTER[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -12,3 +12,23 @@
 	}
 }
 
+@PART[TPtankTri|TPtankCube???]:NEEDS[B9PartSwitch]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitch
+		switcherDescription = Color Scheme
+
+		SUBTYPE
+		{
+			name = Gold
+			transform = TPprobe-Gold
+		}
+		SUBTYPE
+		{
+			name = Silver
+			transform = TPprobe-Silver
+		}
+	}
+}

--- a/GameData/NecroBones/FuelTanksPlus/Size0/000_TPtank0m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/000_TPtank0m_MM.cfg
@@ -1,4 +1,4 @@
-@PART[TPtank0mL?????|TPcone0m*|TPdecoupler0m]:AFTER[FuelTanksPlus]
+@PART[TPtank0mL?????|TPcone0m*|TPdecoupler0m]:NEEDS[Firespitter|InterstellarMeshSwitch&!B9PartSwitch]:AFTER[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -12,3 +12,38 @@
 	}
 }
 
+@PART[TPtank0mL?????|TPcone0m*|TPdecoupler0m]:NEEDS[B9PartSwitch]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitch
+		switcherDescription = Color Scheme
+
+		SUBTYPE
+		{
+			name = Oscar
+			transform = TPtank0m-Grey
+		}
+		SUBTYPE
+		{
+			name = Juno
+			transform = TPtank0m-White
+		}
+		SUBTYPE
+		{
+			name = Astrobee
+			transform = TPtank0m-Checkered
+		}
+		SUBTYPE
+		{
+			name = Brant
+			transform = TPtank0m-Black
+		}
+		SUBTYPE
+		{
+			name = Titan
+			transform = TPtank0m-Red
+		}
+	}
+}

--- a/GameData/NecroBones/FuelTanksPlus/Size1/000_TPtank1m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/000_TPtank1m_MM.cfg
@@ -1,4 +1,4 @@
-@PART[TPcone1m1|TPcone1m2|TPdome1m*|TPtank1mL?????|TPtank1m0mA|TPdecoupler1m]:AFTER[FuelTanksPlus]
+@PART[TPcone1m1|TPcone1m2|TPdome1m*|TPtank1mL?????|TPtank1m0mA|TPdecoupler1m]:NEEDS[Firespitter|InterstellarMeshSwitch&!B9PartSwitch]:AFTER[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -12,3 +12,38 @@
 	}
 }
 
+@PART[TPcone1m1|TPcone1m2|TPdome1m*|TPtank1mL?????|TPtank1m0mA|TPdecoupler1m]:NEEDS[B9PartSwitch]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitch
+		switcherDescription = Color Scheme
+
+		SUBTYPE
+		{
+			name = Vega
+			transform = TPtank1m-White
+		}
+		SUBTYPE
+		{
+			name = Redstone
+			transform = TPtank1m-Checkered
+		}
+		SUBTYPE
+		{
+			name = Vanguard
+			transform = TPtank1m-Black
+		}
+		SUBTYPE
+		{
+			name = Soyuz
+			transform = TPtank1m-Green
+		}
+		SUBTYPE
+		{
+			name = Delta
+			transform = TPtank1m-Blue
+		}
+	}
+}

--- a/GameData/NecroBones/FuelTanksPlus/Size2/000_TPtank2m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/000_TPtank2m_MM.cfg
@@ -1,4 +1,4 @@
-@PART[TPcone2m|TPdome2m|TPtank2mL?????|TPtank2m1mA|TPdecoupler2m]:AFTER[FuelTanksPlus]
+@PART[TPcone2m|TPdome2m|TPtank2mL?????|TPtank2m1mA|TPdecoupler2m]:NEEDS[Firespitter|InterstellarMeshSwitch&!B9PartSwitch]:AFTER[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -12,3 +12,44 @@
 	}
 }
 
+@PART[TPcone2m|TPdome2m|TPtank2mL?????|TPtank2m1mA|TPdecoupler2m]:NEEDS[B9PartSwitch]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitch
+		switcherDescription = Color Scheme
+		
+		SUBTYPE
+		{
+			name = Delta
+			transform = TPtank2m-Orange
+			transform = TPtank2m-Orange2
+		}		
+		SUBTYPE
+		{
+			name = Antares
+			transform = TPtank2m-White
+		}		
+		SUBTYPE
+		{
+			name = Gemini
+			transform = TPtank2m-Checkered
+		}		
+		SUBTYPE
+		{
+			name = Black
+			transform = TPtank2m-Black
+		}		
+		SUBTYPE
+		{
+			name = Blue
+			transform = TPtank2m-Blue
+		}		
+		SUBTYPE
+		{
+			name = Atlas
+			transform = TPtank2m-Red
+		}
+	}
+}

--- a/GameData/NecroBones/FuelTanksPlus/Size3/000_TPtank3m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/000_TPtank3m_MM.cfg
@@ -1,4 +1,4 @@
-@PART[TPcone3m|TPdome3m|TPtank3mL?????|TPtank3m2mA*|TPdecoupler3m]:AFTER[FuelTanksPlus]
+@PART[TPcone3m|TPdome3m|TPtank3mL?????|TPtank3m2mA*|TPdecoupler3m]:NEEDS[Firespitter|InterstellarMeshSwitch&!B9PartSwitch]:AFTER[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -9,6 +9,49 @@
 		affectColliders = false
 		buttonName = Next Color Scheme
 		previousButtonName = Previous Color Scheme
+	}
+}
+
+@PART[TPcone3m|TPdome3m|TPtank3mL?????|TPtank3m2mA*|TPdecoupler3m]:NEEDS[B9PartSwitch]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = meshSwitch
+		switcherDescription = Color Scheme
+
+		SUBTYPE
+		{
+			name = Titan
+			transform = TPtank3m-Silver
+			transform = TPtank3m-SilverShine
+		}
+		SUBTYPE
+		{
+			name = Falcon
+			transform = TPtank3m-White			
+		}
+		SUBTYPE
+		{
+			name = Saturn
+			transform = TPtank3m-Checkered			
+		}
+		SUBTYPE
+		{
+			name = Black
+			transform = TPtank3m-Black			
+		}
+		SUBTYPE
+		{
+			name = STS
+			transform = TPtank3m-Orange
+			transform = TPtank3m-Orange2
+		}
+		SUBTYPE
+		{
+			name = Ariane
+			transform = TPtank3m-Tan
+		}
 	}
 }
 

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "1.8.1.0",
+ "message": "1.8.2.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 1.8.2.0 (2016-04-28) - Mesh switching compatibility

* Added support for B9PartSwitch. Firespitter and InterstellarFuelSwitch still work too, of course.
* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com
* closes #66 - 1.8.2 (2016-04-28) - Mesh switching compatibility
* updates #26 - Previous Releases

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>

---