### PR TITLE
1.9.0.0 (2016-05-06) - Update

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -12,8 +12,8 @@
 	"VERSION" :
 	{
 		"MAJOR" : 1,
-		"MINOR" : 8,
-		"PATCH" : 3,
+		"MINOR" : 9,
+		"PATCH" : 0,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,12 @@
+1.9 (2016-05-06) - Update.
+ - Nuclear (single-propellant) tanks capacity increased to match total units for LFO tanks. Names updated accordingly.
+ - B9PartSwitch fuel-switching enabled for most tanks, Switching config overhauled:
+   - Firespitter and InterstellarFuelSwitch support still included, of course.
+   - Calculated values will differ somewhat from the FS/IFS values, for cost, capacity, etc. This is normal.
+   - Radial tanks with texture-switching still rely on FS/IFS for now. Non-switching if only B9 is installed.
+   - B9 mesh switching has been set not to regenerate drag cubes while attaching in the editors.
+ - Crossfeed available (glabally!) for radially attached parts, enable button added to radial tanks.
+
 1.8.3 (2016-04-29) - Hotfix + Tweaks.
  - Various small clean-ups in the fuel-switching config.
  - Fixed a mistake in 1.8.2 that was preventing InterstellarFuelSwitch integration from working correctly.

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -12,8 +12,8 @@
 	"VERSION" :
 	{
 		"MAJOR" : 1,
-		"MINOR" : 8,
-		"PATCH" : 3,
+		"MINOR" : 9,
+		"PATCH" : 0,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/Patches/FuelTanksPlus_FuelSwitch.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Patches/FuelTanksPlus_FuelSwitch.cfg
@@ -1,5 +1,100 @@
 
-@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+// All fuel switching rules are here. Paint-switching rules are in each of the 
+// category folders with the parts located there, since each size-class has
+// its own set of colors and mesh names.
+
+// NOTE: The "Radial" tanks have the fuel switching configs in their own folder,
+// rather than here, since it's more tightly tied to their color switching, etc.
+
+
+//--------------------------------------------------------------------------------
+// Turn on global radial fuel crossfeed, so that it can be switched on per-tank.
+
+@PHYSICSGLOBALS
+{
+	@stack_PriUsesSurf = True
+}
+
+
+//--------------------------------------------------------------------------------
+// Set up the tank types we use, if B9 is installed:
+
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = FTPOxidizer
+	tankMass = 0.000125
+	tankCost = 0.0
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 1
+	}
+}
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = FTPLiquidFuel
+	tankMass = 0.000125
+	tankCost = 0.0
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 1
+	}
+}
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = FTPLFO
+	tankMass = 0.000125
+	tankCost = 0.0
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.45
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.55
+	}
+}
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = FTPMonoPropellant
+	tankMass = 0.0004
+	tankCost = 1.25
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 1.175
+	}
+}
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = FTPXenon
+	tankMass = 0.0022
+	tankCost = 55
+	RESOURCE
+	{
+		name = XenonGas
+		unitsPerVolume = 28
+	}
+}
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = FTPOre
+	tankMass = 0.00025
+	tankCost = 3.0
+	RESOURCE
+	{
+		name = Ore
+		unitsPerVolume = 2
+	}
+}
+
+//--------------------------------------------------------------------------------
+// Bulk update tanks with Firespitter or InterstellarFuelSwitch:
+
+@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
@@ -21,151 +116,21 @@
 		resourceNames = LiquidFuel,Oxidizer;LiquidFuel;Oxidizer;MonoPropellant
 		resourceAmounts = #$../LF$,$../OX$;$../LF2$;$../OX2$;$../Monoprop$
 		basePartMass = #$../mass$
+
+//Note to self: This can work, but need to figure out monoprop tank mass first:
+//		basePartMass = 0
+//		baseResourceMassDivider = 8
 	}
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
 }
 
-B9_TANK_TYPE:NEEDS[B9PartSwitch]
-{
-	name = FTPOxidizer
-	tankMass = 0.0
-	tankCost = 0.0
-	RESOURCE
-	{
-		name = Oxidizer
-		unitsPerVolume = 1
-	}
-}
-B9_TANK_TYPE:NEEDS[B9PartSwitch]
-{
-	name = FTPLiquidFuel
-	tankMass = 0.0
-	tankCost = 0.0
-	RESOURCE
-	{
-		name = LiquidFuel
-		unitsPerVolume = 1
-	}
-}
-B9_TANK_TYPE:NEEDS[B9PartSwitch]
-{
-	name = FTPLFO
-	tankMass = 0.0
-	tankCost = 0.0
-	RESOURCE
-	{
-		name = LiquidFuel
-		unitsPerVolume = 0.45
-	}
-	RESOURCE
-	{
-		name = Oxidizer
-		unitsPerVolume = 0.55
-	}
-}
-B9_TANK_TYPE:NEEDS[B9PartSwitch]
-{
-	name = FTPMonoPropellant
-	tankMass = 0.0
-	tankCost = 0.0
-	RESOURCE
-	{
-		name = MonoPropellant
-		unitsPerVolume = 1.175
-	}
-}
-
-@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[B9PartSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
-{
-	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
-	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
-
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank Type
-		baseVolume = #$../totalCap$
-
-		SUBTYPE
-		{
-			name = LF/O
-			tankType = FTPLFO
-			addedMass = 0
-		}
-		SUBTYPE
-		{
-			name = Oxidizer
-			tankType = FTPOxidizer
-			addedMass = 0
-		}
-		SUBTYPE
-		{
-			name = LiquidFuel
-			tankType = FTPLiquidFuel
-			addedMass = 0
-		}
-		SUBTYPE
-		{
-			name = MonoPropellant
-			tankType = FTPMonoPropellant
-			addedMass = 0
-		}
-	}
-	!RESOURCE[LiquidFuel] {}
-	!RESOURCE[Oxidizer] {}
-}
-
-@PART[TPtankTri]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[Firespitter|InterstellarFuelSwitch]:NEEDS[!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
-{
-	MODULE
-	{
-		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
-		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
-		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
-		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
-		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;Xenon;MonoPropellant
-		resourceNames = LiquidFuel,Oxidizer;XenonGas;MonoPropellant
-		resourceAmounts = 22.5,27.5;2800;235
-		basePartMass = 0.035
-		tankMass = 0.0;0.09;0.0
-	}
-	!RESOURCE[LiquidFuel] {}
-	!RESOURCE[Oxidizer] {}
-}
-
-@PART[TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[Firespitter|InterstellarFuelSwitch]:NEEDS[!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
-{
-	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
-	%OX = #$RESOURCE[Oxidizer]/maxAmount$
-
-	%Xenon = #$mass$
-	@Xenon *= 14000
-	%Monoprop = #$mass$
-	@Monoprop *= 1880
-
-	MODULE
-	{
-		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
-		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
-		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
-		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
-		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;Xenon;MonoPropellant
-		resourceNames = LiquidFuel,Oxidizer;XenonGas;MonoPropellant
-		resourceAmounts = #$../LF$,$../OX$;$../Xenon$;$../Monoprop$
-		basePartMass = #$../mass$
-	}
-	!RESOURCE[LiquidFuel] {}
-	!RESOURCE[Oxidizer] {}
-}
-
-@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[Firespitter|InterstellarFuelSwitch]:NEEDS[!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$LF$
-	@OX *= 11
-	@OX /= 9
+	//@OX *= 11
+	//@OX /= 9
 
 	%XenonMass = #$mass$
 	@XenonMass *= 3.3
@@ -195,6 +160,193 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 }
 
 
+@PART[TPtankTri]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+{
+	MODULE
+	{
+		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
+		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;Xenon;MonoPropellant
+		resourceNames = LiquidFuel,Oxidizer;XenonGas;MonoPropellant
+		resourceAmounts = 22.5,27.5;2800;235
+		basePartMass = 0.035
+		tankMass = 0.0;0.09;0.0
+	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+}
+
+@PART[TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+{
+	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
+	%OX = #$RESOURCE[Oxidizer]/maxAmount$
+
+	%Xenon = #$mass$
+	@Xenon *= 14000
+	%Monoprop = #$mass$
+	@Monoprop *= 1880
+
+	MODULE
+	{
+		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
+		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;Xenon;MonoPropellant
+		resourceNames = LiquidFuel,Oxidizer;XenonGas;MonoPropellant
+		resourceAmounts = #$../LF$,$../OX$;$../Xenon$;$../Monoprop$
+		basePartMass = #$../mass$
+	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+}
+
+
+
+
+//--------------------------------------------------------------------------------
+// Bulk update tanks with B9PartSwitch:
+
+
+@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+{
+	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
+	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
+
+	%massOffset = #$mass$
+	@massOffset *= -1
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = fuelSwitch
+		switcherDescription = Tank Type
+		baseVolume = #$../totalCap$
+
+		SUBTYPE
+		{
+			name = LF/O
+			tankType = FTPLFO
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			tankType = FTPLiquidFuel
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = Oxidizer
+			tankType = FTPOxidizer
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			tankType = FTPMonoPropellant
+			addedMass = #$../../massOffset$
+		}
+	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+}
+
+@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+{
+	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
+
+	%massOffset = #$mass$
+	@massOffset *= -1
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = fuelSwitch
+		switcherDescription = Tank Type
+		baseVolume = #$../totalCap$
+
+		SUBTYPE
+		{
+			name = LiquidFuel
+			tankType = FTPLiquidFuel
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = Oxidizer
+			tankType = FTPOxidizer
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = XenonGas
+			tankType = FTPXenon
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			tankType = FTPMonoPropellant
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = Ore
+			tankType = FTPOre
+			addedMass = #$../../massOffset$
+		}
+	}
+	!RESOURCE[LiquidFuel] {}
+}
+
+
+@PART[TPtankTri|TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+{
+	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
+	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
+
+	%massOffset = #$mass$
+	@massOffset *= -1
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = fuelSwitch
+		switcherDescription = Tank Type
+		baseVolume = #$../totalCap$
+
+		SUBTYPE
+		{
+			name = LF/O
+			tankType = FTPLFO
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = XenonGas
+			tankType = FTPXenon
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			tankType = FTPMonoPropellant
+			addedMass = #$../../massOffset$
+		}
+	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+}
+
+
+
+//--------------------------------------------------------------------------------
+// Delete temporary variables:
+
+
 @PART[TPtank*|TPdome*|TPcone*]:FOR[zFuelTanksPlus]
 {
 	!LF = 0
@@ -208,7 +360,12 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	!XenonMass = 0
 	!Ore = 0
 	!OreMass = 0
+	!massOffset = 0
 }
+
+
+
+//--------------------------------------------------------------------------------
 
 
 

--- a/GameData/NecroBones/FuelTanksPlus/Probe/000_TPtankP_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Probe/000_TPtankP_MM.cfg
@@ -19,6 +19,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Color Scheme
+		affectDragCubes = false
 
 		SUBTYPE
 		{

--- a/GameData/NecroBones/FuelTanksPlus/Radial/000_TPtankR_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Radial/000_TPtankR_MM.cfg
@@ -1,4 +1,53 @@
-@PART[TPtankR??]
+
+// Radial tanks have texture-switching instead of mesh switching. For this reason,
+// they still prefer to use FS or IFS for switching. B9PartSwitch will only be used
+// if the other two are absent.
+
+@PART[TTPtankR??]:NEEDS[B9PartSwitch&!Firespitter&!InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+{
+	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
+	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
+
+	%massOffset = #$mass$
+	@massOffset *= -1
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = fuelSwitch
+		switcherDescription = Tank Type
+		baseVolume = #$../totalCap$
+
+		SUBTYPE
+		{
+			name = MonoPropellant
+			tankType = FTPMonoPropellant
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = LF/O
+			tankType = FTPLFO
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			tankType = FTPLiquidFuel
+			addedMass = #$../../massOffset$
+		}
+		SUBTYPE
+		{
+			name = Oxidizer
+			tankType = FTPOxidizer
+			addedMass = #$../../massOffset$
+		}
+	}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+}
+
+@PART[TPtankR??]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:AFTER[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -15,4 +64,62 @@
 		statusText = Current Variant
 	}
 }
+
+@PART[TPtankR01]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
+		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
+		resourceAmounts = 125;45,55;90;110
+		tankMass = 0.125;0.035;0.035;0.035
+		basePartMass = 0.0
+		displayCurrentTankCost = true
+		hasGUI = false
+		availableInFlight = false
+		availableInEditor = true
+		showInfo = false
+	}
+}
+
+@PART[TPtankR02]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
+		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
+		resourceAmounts = 250;90,110;180;220
+		tankMass = 0.25;0.0625;0.0625;0.0625
+		basePartMass = 0.0
+		displayCurrentTankCost = true
+		hasGUI = false
+		availableInFlight = false
+		availableInEditor = true
+		showInfo = false
+	}
+}
+
+@PART[TPtankR03]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:AFTER[FuelTanksPlus]
+{
+	MODULE
+	{
+		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
+		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
+		resourceAmounts = 600;180,220;360;440
+		tankMass = 0.6;0.125;0.125;0.125
+		basePartMass = 0.0
+		displayCurrentTankCost = true
+		hasGUI = false
+		availableInFlight = false
+		availableInEditor = true
+		showInfo = false
+	}
+}
+
+
+
+
 

--- a/GameData/NecroBones/FuelTanksPlus/Radial/TPtankR01.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Radial/TPtankR01.cfg
@@ -49,25 +49,17 @@ RESOURCE
  maxAmount = 55
 }
 
+
+
 	MODULE
 	{
-		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
-		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
-		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
-		resourceAmounts = 125;45,55;90;110
-		tankMass = 0.125;0.035;0.035;0.035
-		basePartMass = 0.0
-		displayCurrentTankCost = true
-		hasGUI = false
-		availableInFlight = false
-		availableInEditor = true
-		showInfo = false
+		name = ModuleCrossFeed
 	}
-
-
-MODULE
-{
-	name = ModuleCrossFeed
-}
-
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = false
+		toggleEditor = true
+		toggleFlight = true
+	}
 }

--- a/GameData/NecroBones/FuelTanksPlus/Radial/TPtankR02.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Radial/TPtankR02.cfg
@@ -49,25 +49,17 @@ RESOURCE
  maxAmount = 110
 }
 
+
 	MODULE
 	{
-		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
-		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
-		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
-		resourceAmounts = 250;90,110;180;220
-		tankMass = 0.25;0.0625;0.0625;0.0625
-		basePartMass = 0.0
-		displayCurrentTankCost = true
-		hasGUI = false
-		availableInFlight = false
-		availableInEditor = true
-		showInfo = false
+		name = ModuleCrossFeed
 	}
 
-
-MODULE
-{
-	name = ModuleCrossFeed
-}
-
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = false
+		toggleEditor = true
+		toggleFlight = true
+	}
 }

--- a/GameData/NecroBones/FuelTanksPlus/Radial/TPtankR03.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Radial/TPtankR03.cfg
@@ -49,24 +49,17 @@ RESOURCE
  maxAmount = 220
 }
 
+
+
 	MODULE
 	{
-		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
-		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
-		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
-		resourceAmounts = 600;180,220;360;440
-		tankMass = 0.6;0.125;0.125;0.125
-		basePartMass = 0.0
-		displayCurrentTankCost = true
-		hasGUI = false
-		availableInFlight = false
-		availableInEditor = true
-		showInfo = false
+		name = ModuleCrossFeed
 	}
-
-MODULE
-{
-	name = ModuleCrossFeed
-}
-
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = false
+		toggleEditor = true
+		toggleFlight = true
+	}
 }

--- a/GameData/NecroBones/FuelTanksPlus/Size0/000_TPtank0m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size0/000_TPtank0m_MM.cfg
@@ -19,6 +19,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Color Scheme
+		affectDragCubes = false
 
 		SUBTYPE
 		{

--- a/GameData/NecroBones/FuelTanksPlus/Size1/000_TPtank1m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/000_TPtank1m_MM.cfg
@@ -19,6 +19,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Color Scheme
+		affectDragCubes = false
 
 		SUBTYPE
 		{

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL00938-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL00938-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 275
 	category = FuelTank
 	subcategory = 0
-	title = FL-T180-Nuclear Propellant Tank
+	title = FL-T200N Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 180
-		maxAmount = 180
+		amount = 200
+		maxAmount = 200
 	}
 
 	MODULE

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL01875-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL01875-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 500
 	category = FuelTank
 	subcategory = 0
-	title = FL-T360-Nuclear Propellant Tank
+	title = FL-T400N Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 360
-		maxAmount = 360
+		amount = 400
+		maxAmount = 400
 	}
 
 	MODULE

--- a/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL03750-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size1/TPtank1mL03750-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 800
 	category = FuelTank
 	subcategory = 0
-	title = FL-T720-Nuclear Propellant Tank
+	title = FL-T800N Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 720
-		maxAmount = 720
+		amount = 800
+		maxAmount = 800
 	}
 
 	MODULE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/000_TPtank2m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/000_TPtank2m_MM.cfg
@@ -19,7 +19,8 @@
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Color Scheme
-		
+		affectDragCubes = false
+
 		SUBTYPE
 		{
 			name = Delta

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL01875-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL01875-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 1550
 	category = FuelTank
 	subcategory = 0
-	title = Rockomax Nuclear-14 Propellant Tank
+	title = Rockomax Nuc-16 Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 1440
-		maxAmount = 1440
+		amount = 1600
+		maxAmount = 1600
 	}
 
 	MODULE

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL03750-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL03750-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 3000
 	category = FuelTank
 	subcategory = 0
-	title = Rockomax Nuclear-28 Propellant Tank
+	title = Rockomax Nuc-32 Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 2880
-		maxAmount = 2880
+		amount = 3200
+		maxAmount = 3200
 	}
 	MODULE
 	{

--- a/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL07500-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size2/TPtank2mL07500-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 5750
 	category = FuelTank
 	subcategory = 0
-	title = Rockomax Nuclear-57 Propellant Tank
+	title = Rockomax Nuc-64 Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 5760
-		maxAmount = 5760
+		amount = 6400
+		maxAmount = 6400
 	}
 
 	MODULE

--- a/GameData/NecroBones/FuelTanksPlus/Size3/000_TPtank3m_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/000_TPtank3m_MM.cfg
@@ -19,6 +19,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Color Scheme
+		affectDragCubes = false
 
 		SUBTYPE
 		{

--- a/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL03750-Nuke.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Size3/TPtank3mL03750-Nuke.cfg
@@ -20,7 +20,7 @@ PART
 	cost = 6500
 	category = FuelTank
 	subcategory = 0
-	title = Kerbodyne S3-6480-FTP Propellant Tank
+	title = Kerbodyne S3-7200-FTP Propellant Tank
 	manufacturer = Fuel Tanks Plus
 	description = This container is designed to hold Liquid Fuel only, for use with nuclear rocket engines.
 
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 6480
-		maxAmount = 6480
+		amount = 7200
+		maxAmount = 7200
 	}
 
 	MODULE

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "1.8.3.0",
+ "message": "1.9.0.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 1.9.0.0 (2016-05-06) - Update

* Nuclear (single-propellant) tanks capacity increased to match total units for LFO tanks. Names updated accordingly.
* B9PartSwitch fuel-switching enabled for most tanks, Switching config overhauled:
  * Firespitter and InterstellarFuelSwitch support still included, of course.
  * Calculated values will differ somewhat from the FS/IFS values, for cost, capacity, etc. This is normal.
  * Radial tanks with texture-switching still rely on FS/IFS for now. Non-switching if only B9 is installed.
  * B9 mesh switching has been set not to regenerate drag cubes while attaching in the editors.
* Crossfeed available (globally!) for radially attached parts, enable button added to radial tanks.
* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com
* closes #68 - 1.9 (2016-05-06) - Update
* updates #26 - Previous Releases

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>

---