### PR TITLE
1.9.1.0 (2016-05-06) - Fuel Switching Tweaks

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 9,
-		"PATCH" : 0,
+		"PATCH" : 1,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,8 @@
+1.9.1 (2016-05-06) - Fuel Switching Tweaks.
+ - Added minimum tech requirements for some fuels in the fuel switchers, when using InterstellarFuelSwitch 2.0.1+.
+ - InterstellarFuelSwitch GUI names updated for IFS 2.0.1.
+ - InterstellarFuelSwitch prioritized ahead of B9PartSwitch to take advantage of tech levels. 
+
 1.9 (2016-05-06) - Update.
  - Nuclear (single-propellant) tanks capacity increased to match total units for LFO tanks. Names updated accordingly.
  - B9PartSwitch fuel-switching enabled for most tanks, Switching config overhauled:
@@ -5,7 +10,7 @@
    - Calculated values will differ somewhat from the FS/IFS values, for cost, capacity, etc. This is normal.
    - Radial tanks with texture-switching still rely on FS/IFS for now. Non-switching if only B9 is installed.
    - B9 mesh switching has been set not to regenerate drag cubes while attaching in the editors.
- - Crossfeed available (glabally!) for radially attached parts, enable button added to radial tanks.
+ - Crossfeed available (globally!) for radially attached parts, enable button added to radial tanks.
 
 1.8.3 (2016-04-29) - Hotfix + Tweaks.
  - Various small clean-ups in the fuel-switching config.

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 9,
-		"PATCH" : 0,
+		"PATCH" : 1,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/Patches/FuelTanksPlus_FuelSwitch.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Patches/FuelTanksPlus_FuelSwitch.cfg
@@ -94,7 +94,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 //--------------------------------------------------------------------------------
 // Bulk update tanks with Firespitter or InterstellarFuelSwitch:
 
-@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
@@ -112,20 +112,18 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
 		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
 		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = LF+OX;LiquidFuel;Oxidizer;MonoProp
 		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;LiquidFuel;Oxidizer;MonoPropellant
 		resourceNames = LiquidFuel,Oxidizer;LiquidFuel;Oxidizer;MonoPropellant
 		resourceAmounts = #$../LF$,$../OX$;$../LF2$;$../OX2$;$../Monoprop$
 		basePartMass = #$../mass$
-
-//Note to self: This can work, but need to figure out monoprop tank mass first:
-//		basePartMass = 0
-//		baseResourceMassDivider = 8
+		tankTechReq:NEEDS[InterstellarFuelSwitch] = start;start;start;advFuelSystems
 	}
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
 }
 
-@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$LF$
@@ -150,17 +148,19 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
 		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
 		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = LiquidFuel;Oxidizer;Xenon;MonoProp;Ore
 		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel;Oxidizer;Xenon;MonoPropellant;Ore
 		resourceNames = LiquidFuel;Oxidizer;XenonGas;MonoPropellant;Ore
 		resourceAmounts = #$../LF$;$../OX$;$../Xenon$;$../Monoprop$;$../Ore$
 		basePartMass = 0
 		tankMass = #$../mass$;$../mass$;$../XenonMass$;$../mass$;$../OreMass$
+		tankTechReq:NEEDS[InterstellarFuelSwitch] = start;start;ionPropulsion;advFuelSystems;advScienceTech
 	}
 	!RESOURCE[LiquidFuel] {}
 }
 
 
-@PART[TPtankTri]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtankTri]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	MODULE
 	{
@@ -168,17 +168,19 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
 		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
 		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = LF+OX;Xenon;MonoProp
 		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;Xenon;MonoPropellant
 		resourceNames = LiquidFuel,Oxidizer;XenonGas;MonoPropellant
 		resourceAmounts = 22.5,27.5;2800;235
 		basePartMass = 0.035
 		tankMass = 0.0;0.09;0.0
+		tankTechReq:NEEDS[InterstellarFuelSwitch] = start;ionPropulsion;advFuelSystems
 	}
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
 }
 
-@PART[TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[Firespitter|InterstellarFuelSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$
@@ -194,10 +196,12 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
 		volumeMultiplier:NEEDS[InterstellarFuelSwitch] = 1
 		massMultiplier:NEEDS[InterstellarFuelSwitch] = 1
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = LF+OX;Xenon;MonoProp
 		resourceGui:NEEDS[InterstellarFuelSwitch] = LiquidFuel+Oxidizer;Xenon;MonoPropellant
 		resourceNames = LiquidFuel,Oxidizer;XenonGas;MonoPropellant
 		resourceAmounts = #$../LF$,$../OX$;$../Xenon$;$../Monoprop$
 		basePartMass = #$../mass$
+		tankTechReq:NEEDS[InterstellarFuelSwitch] = start;ionPropulsion;advFuelSystems
 	}
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}
@@ -210,7 +214,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 // Bulk update tanks with B9PartSwitch:
 
 
-@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtankL*|TPtank?mL*|TPdome*|TPcone*|TPtank?m?mA]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!Firespitter&!InterstellarFuelSwitch&!CryoTanks&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
 	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$
@@ -254,7 +258,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	!RESOURCE[Oxidizer] {}
 }
 
-@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtank?mL?????-Nuke]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!Firespitter&!InterstellarFuelSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
 
@@ -303,7 +307,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 }
 
 
-@PART[TPtankTri|TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
+@PART[TPtankTri|TPtankCube*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch]]:NEEDS[B9PartSwitch&!Firespitter&!InterstellarFuelSwitch&!CryoEngines&!ModularFuelTanks&!RealFuels]:FOR[FuelTanksPlus]
 {
 	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
 	@totalCap += #$RESOURCE[Oxidizer]/maxAmount$

--- a/GameData/NecroBones/FuelTanksPlus/Radial/000_TPtankR_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Radial/000_TPtankR_MM.cfg
@@ -71,6 +71,7 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
 		resourceAmounts = 125;45,55;90;110
 		tankMass = 0.125;0.035;0.035;0.035
@@ -89,6 +90,7 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
 		resourceAmounts = 250;90,110;180;220
 		tankMass = 0.25;0.0625;0.0625;0.0625
@@ -107,6 +109,7 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
 		resourceAmounts = 600;180,220;360;440
 		tankMass = 0.6;0.125;0.125;0.125

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "1.9.0.0",
+ "message": "1.9.1.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 1.9.1.0 (2016-05-06) - Fuel Switching Tweaks

* Added minimum tech requirements for some fuels in the fuel switchers, when using InterstellarFuelSwitch 2.0.1+.
* InterstellarFuelSwitch GUI names updated for IFS 2.0.1.
* InterstellarFuelSwitch prioritized ahead of B9PartSwitch to take advantage of tech levels.
* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com
* closes #69 - 1.9.1 (2016-05-06) - Fuel Switching Tweaks
* updates #26 - Previous Releases

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>

---