### PR TITLE
1.9.2.0 (2016-05-07) - Fuel Switching Tweaks

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 9,
-		"PATCH" : 1,
+		"PATCH" : 2,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,7 @@
+1.9.2 (2016-05-07) - Fuel Switching Tweaks.
+ - Added InterstellarFuelSwitch 2.0.2 flags to re-tie radial tank texture to fuel type.
+ - Reduced dry mass of radial tanks when containing MonoPropellant, to better match stock tanks (Firespitter and InterstellarFuelSwitch).
+
 1.9.1 (2016-05-06) - Fuel Switching Tweaks.
  - Added minimum tech requirements for some fuels in the fuel switchers, when using InterstellarFuelSwitch 2.0.1+.
  - InterstellarFuelSwitch GUI names updated for IFS 2.0.1.

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 9,
-		"PATCH" : 1,
+		"PATCH" : 2,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/NecroBones/FuelTanksPlus/Radial/000_TPtankR_MM.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/Radial/000_TPtankR_MM.cfg
@@ -53,6 +53,8 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FStextureSwitch2
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarTextureSwitch2
+		hasSwitchChooseOption:NEEDS[InterstellarFuelSwitch] = False
+		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		textureRootFolder = FuelTanksPlus/Radial/
 		textureNames = TPtankR-rimGold-Specular;TPtankR-rimBlack-Specular;TPtankR-rimRed-Specular;TPtankR-rimBlue-Specular
 		textureDisplayNames = MonoPropellant;LF+OX;LiquidFuel;Oxidizer
@@ -71,10 +73,11 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		useTextureSwitchModule:NEEDS[InterstellarFuelSwitch] = True
 		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
 		resourceAmounts = 125;45,55;90;110
-		tankMass = 0.125;0.035;0.035;0.035
+		tankMass = 0.0675;0.035;0.035;0.035
 		basePartMass = 0.0
 		displayCurrentTankCost = true
 		hasGUI = false
@@ -90,10 +93,11 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		useTextureSwitchModule:NEEDS[InterstellarFuelSwitch] = True
 		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
 		resourceAmounts = 250;90,110;180;220
-		tankMass = 0.25;0.0625;0.0625;0.0625
+		tankMass = 0.135;0.0625;0.0625;0.0625
 		basePartMass = 0.0
 		displayCurrentTankCost = true
 		hasGUI = false
@@ -109,10 +113,11 @@
 	{
 		name:NEEDS[!InterstellarFuelSwitch] = FSfuelSwitch
 		name:NEEDS[InterstellarFuelSwitch] = InterstellarFuelSwitch
+		useTextureSwitchModule:NEEDS[InterstellarFuelSwitch] = True
 		tankSwitchNames:NEEDS[InterstellarFuelSwitch] = MonoProp;LF+OX;LiquidFuel;Oxidizer
 		resourceNames = MonoPropellant;LiquidFuel,Oxidizer;LiquidFuel;Oxidizer
 		resourceAmounts = 600;180,220;360;440
-		tankMass = 0.6;0.125;0.125;0.125
+		tankMass = 0.325;0.125;0.125;0.125
 		basePartMass = 0.0
 		displayCurrentTankCost = true
 		hasGUI = false

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "1.9.1.0",
+ "message": "1.9.2.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 1.9.2.0 (2016-05-07) - Fuel Switching Tweaks

* Added InterstellarFuelSwitch 2.0.2 flags to re-tie radial tank texture to fuel type.
* Reduced dry mass of radial tanks when containing MonoPropellant, to better match stock tanks (Firespitter and InterstellarFuelSwitch).
* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com
* closes #70 - 1.9.2 (2016-05-07) - Fuel Switching Tweaks
* updates #26 - Previous Releases

---