### PR TITLE
2.0.2.0 (2018-03-14) - RCS fixes

### DIFF
--- a/FuelTanksPlus.version
+++ b/FuelTanksPlus.version
@@ -13,14 +13,14 @@
 	{
 		"MAJOR" : 2,
 		"MINOR" : 0,
-		"PATCH" : 1,
+		"PATCH" : 2,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 4,
-		"PATCH" : 0
+		"PATCH" : 4
 	},
 	"KSP_VERSION_MIN" :
 	{

--- a/GameData/NecroBones/FuelTanksPlus/2.0.2.0.htm
+++ b/GameData/NecroBones/FuelTanksPlus/2.0.2.0.htm
@@ -6,10 +6,10 @@ updated: 30 Mar 2022 -->
 <p><a
 href="https://forum.kerbalspaceprogram.com/index.php?/topic/207702-*"
 title="Fuel Tanks Plus on the forums"><img
-src="https://img.shields.io/badge/FuelTanksPlus%20(FTP)%20v-2.0.1.0--release-BADA55.svg?style=plastic&amp;labelColor=darkgreen"
-title="2.0.1.0-release" alt="Fuel Tanks Plus Version" /></a> <a
+src="https://img.shields.io/badge/FuelTanksPlus%20(FTP)%20v-2.0.2.0--release-BADA55.svg?style=plastic&amp;labelColor=darkgreen"
+title="2.0.2.0-release" alt="Fuel Tanks Plus Version" /></a> <a
 href="http://kerbalspaceprogram.com/" title="Kerbal Space Program"><img
-src="https://img.shields.io/badge/KSP-1.4.0-blue.svg?style=plastic&amp;logo=data:image/webp;base64,UklGRpAGAABXRUJQVlA4TIQGAAAvH8AHEE0obNsGDakwXkT/Q4chj76jn1yYjSRjH6H+6xQqRUkkSc5ckHD+NUUVhx4+RNu2bTTl/3OTVhD6H8u6fF8dDYm40CK7N0CjAxK52rYtjfQRAvGNjbu7V+vuLp2fwhzA6gG4li6de+nuO+4uJBlkwoTA//90kENgtZZs27ZpO2Oufa5vbNsq2Sw6qaa9r3n/kZJTex/wSrFt27o62kuSJNuqrdTa1+/7uLu7uzQZAk0mRN/mAz2CAbi723vvy5WztxxIAAiw+dh2bdvWZJuT12y1bdu2bdu2bbs3AQABlsED+y50lDqLE4pf/Uxe8KO77HFes9hvxu1p3O2Q09LVg0NVjo7Z5U6AvwBSOfivKdQTujOnXNG8hzNhqYSMMHJ+MwWWyTSjNUoP1jWHp1ZNmgB8TMH3Tl33mvoVb8uIj3umyIJLsAmYoCIqUCVMCN5WrW78Qi+AkeaGOkWFk3QbRmIWHpIZSURXDxhJVlJiYZ6kLEgeEjIRCBmxebhCTWlTJNaXLystGysVToPOAFJJjqSPNOXftSVbXPQjxrzVaFNzXvBonWJlonIVTJabAfjZ0Jxufl5GPntEHKjB7PIXtg6eYHywJn3hTdijjXUain94KjfCfg1hm³AZRR4N16VMXBrsDVYDCjOIMmGFsAab8rdY7+kIw0BgtRgL1DKJeuNZdQ9f5RAGGfOQfZxexj7t37RkjNp4rPDIHOJVyPBF+XHKsnQk4SWRBl8Wot74WtkBqidQggbyj2vW1WEFG6JfUZ8UxhVzOmAUdKTYZ3yxR2QwIIAQdA9YgiRBZWyCguiOER9y9IauiyGqR0EayVLiEVwmXmF5+Z2jfohj8i1q8ybRahCBAXZBCBUqLgAACQFzp5M/o5wzCDcCJZEOF9EzggM7NEd18c1Q85gPBldtg6mwB1N+hzyTSFp5jWM+WpCRBEBAjIaUxJI80o3s6vDYJ7gNXuAUfOacvsLvLhNIMaMwh8GccsXjtuiK+wkxZ/kVdOCzoCeAOn+N7H1rU1YT35MgAWY9yD5wMWI7j7G976bSh8LxDx2jI3IJRAnJ+RQQIU7gABnLd3vKSyMAd71mq7HgV3AJ+Sxh5Bz5O0z/gbTiNT8DxQssrrv7Uyx9Y7q6BQVUoIGonF/FfoC/RqwVHlviCRSABDvLaCUfZlz1cNENn6adNTz+AF8v8KWQAFL+QMkpCthFkpvvq7+2/to6AIBhyvPdrUr3g1XwBEJPMeP/98SxWWvs3nHIhgNnsY1RWVyw+Guh5IZLgj9WzPi/iEk9gPPGLAni3aRlsqlGQ9jP4z9Q/s/xi3dw486abm6Bqi2l3qu9e9tQsdVMdG4zbVYqp5wJcBSA2W6sNmkwxuNk+nw3r4MFi/4EkTAhiRFk70jkqNDiWbDK65OLIn0s0wD/ucAp3XwVSsSNBAqjFUIXwFE0MihZQ6utQYV2oR+tShO7Ad6bswY3xd7qe0VrVxK9ZjueQy4TPnF8MCQGjoxSugSFgFMV4LiVwgsn/i+gXZ2FzplAduxnn0/OlW0uqf+M64MRPqzwrl+PnpKQSaXS49Ui7n2/ctFtHtAtiprzxq6WniwESvW5yUG1Xx6/8Hx8NKELwKZK15pV/EvXvm9ZMlx0aKUO98iUPaWvst/n8ZbOmkvGhcOQRWf5zj9dk9cfpad5oHN3Rns/wsuvy2puxz1Ziu96Q7/SOWoROzvNzFo5Z5+1BDej3OjQ/XymEkW9jr0em5g5SdX8VC2gf9xJb/RWCC5bIKWDgWcYf+K9Kje3zbQBh/F448wMLoICeUyJ330nXlPmawiRT/sblG4vWrbErgQaMzYbZcwbhSaNrwH+Tqa04jqrd3JZTvwbFxHFSVMAv5UZdEq+tQUupcis/5+MZNsxk9b8TPa7cMqdzzrh9FtD5v+vPACvJy7nDT69IP/Yx6EywGdTFsD5iU7bqkovJogzTjQm³iFTyp4jV4bjVKdcnv5/JrhokmpnGAIA4D/AXYCfVgoBXnrDkCqqCHRG529HeYB51Jy1z6nlW/gnVmzyxmVHxnQrxXxelcI0yN85udPl+//t2rzKzA+oluPTNjp6qY1PVduFVdo8ya+8E6p8KOZR+bLj6Vju9oi5dar0erTS8Z1x3/IITU3vyDRLiZWBZVH6CbqURTeLptD3pEPIR4W4QlHfTnRJzZBRJ8MlI8LmmEXLAdAxsqIYbSDGTt65GfF0cUL6aQQ=&amp;labelColor=black"
+src="https://img.shields.io/badge/KSP-1.4.4-blue.svg?style=plastic&amp;logo=data:image/webp;base64,UklGRpAGAABXRUJQVlA4TIQGAAAvH8AHEE0obNsGDakwXkT/Q4chj76jn1yYjSRjH6H+6xQqRUkkSc5ckHD+NUUVhx4+RNu2bTTl/3OTVhD6H8u6fF8dDYm40CK7N0CjAxK52rYtjfQRAvGNjbu7V+vuLp2fwhzA6gG4li6de+nuO+4uJBlkwoTA//90kENgtZZs27ZpO2Oufa5vbNsq2Sw6qaa9r3n/kZJTex/wSrFt27o62kuSJNuqrdTa1+/7uLu7uzQZAk0mRN/mAz2CAbi723vvy5WztxxIAAiw+dh2bdvWZJuT12y1bdu2bdu2bbs3AQABlsED+y50lDqLE4pf/Uxe8KO77HFes9hvxu1p3O2Q09LVg0NVjo7Z5U6AvwBSOfivKdQTujOnXNG8hzNhqYSMMHJ+MwWWyTSjNUoP1jWHp1ZNmgB8TMH3Tl33mvoVb8uIj3umyIJLsAmYoCIqUCVMCN5WrW78Qi+AkeaGOkWFk3QbRmIWHpIZSURXDxhJVlJiYZ6kLEgeEjIRCBmxebhCTWlTJNaXLystGysVToPOAFJJjqSPNOXftSVbXPQjxrzVaFNzXvBonWJlonIVTJabAfjZ0Jxufl5GPntEHKjB7PIXtg6eYHywJn3hTdijjXUain94KjfCfg1hm³AZRR4N16VMXBrsDVYDCjOIMmGFsAab8rdY7+kIw0BgtRgL1DKJeuNZdQ9f5RAGGfOQfZxexj7t37RkjNp4rPDIHOJVyPBF+XHKsnQk4SWRBl8Wot74WtkBqidQggbyj2vW1WEFG6JfUZ8UxhVzOmAUdKTYZ3yxR2QwIIAQdA9YgiRBZWyCguiOER9y9IauiyGqR0EayVLiEVwmXmF5+Z2jfohj8i1q8ybRahCBAXZBCBUqLgAACQFzp5M/o5wzCDcCJZEOF9EzggM7NEd18c1Q85gPBldtg6mwB1N+hzyTSFp5jWM+WpCRBEBAjIaUxJI80o3s6vDYJ7gNXuAUfOacvsLvLhNIMaMwh8GccsXjtuiK+wkxZ/kVdOCzoCeAOn+N7H1rU1YT35MgAWY9yD5wMWI7j7G976bSh8LxDx2jI3IJRAnJ+RQQIU7gABnLd3vKSyMAd71mq7HgV3AJ+Sxh5Bz5O0z/gbTiNT8DxQssrrv7Uyx9Y7q6BQVUoIGonF/FfoC/RqwVHlviCRSABDvLaCUfZlz1cNENn6adNTz+AF8v8KWQAFL+QMkpCthFkpvvq7+2/to6AIBhyvPdrUr3g1XwBEJPMeP/98SxWWvs3nHIhgNnsY1RWVyw+Guh5IZLgj9WzPi/iEk9gPPGLAni3aRlsqlGQ9jP4z9Q/s/xi3dw486abm6Bqi2l3qu9e9tQsdVMdG4zbVYqp5wJcBSA2W6sNmkwxuNk+nw3r4MFi/4EkTAhiRFk70jkqNDiWbDK65OLIn0s0wD/ucAp3XwVSsSNBAqjFUIXwFE0MihZQ6utQYV2oR+tShO7Ad6bswY3xd7qe0VrVxK9ZjueQy4TPnF8MCQGjoxSugSFgFMV4LiVwgsn/i+gXZ2FzplAduxnn0/OlW0uqf+M64MRPqzwrl+PnpKQSaXS49Ui7n2/ctFtHtAtiprzxq6WniwESvW5yUG1Xx6/8Hx8NKELwKZK15pV/EvXvm9ZMlx0aKUO98iUPaWvst/n8ZbOmkvGhcOQRWf5zj9dk9cfpad5oHN3Rns/wsuvy2puxz1Ziu96Q7/SOWoROzvNzFo5Z5+1BDej3OjQ/XymEkW9jr0em5g5SdX8VC2gf9xJb/RWCC5bIKWDgWcYf+K9Kje3zbQBh/F448wMLoICeUyJ330nXlPmawiRT/sblG4vWrbErgQaMzYbZcwbhSaNrwH+Tqa04jqrd3JZTvwbFxHFSVMAv5UZdEq+tQUupcis/5+MZNsxk9b8TPa7cMqdzzrh9FtD5v+vPACvJy7nDT69IP/Yx6EywGdTFsD5iU7bqkovJogzTjQm³iFTyp4jV4bjVKdcnv5/JrhokmpnGAIA4D/AXYCfVgoBXnrDkCqqCHRG529HeYB51Jy1z6nlW/gnVmzyxmVHxnQrxXxelcI0yN85udPl+//t2rzKzA+oluPTNjp6qY1PVduFVdo8ya+8E6p8KOZR+bLj6Vju9oi5dar0erTS8Z1x3/IITU3vyDRLiZWBZVH6CbqURTeLptD3pEPIR4W4QlHfTnRJzZBRJ8MlI8LmmEXLAdAxsqIYbSDGTt65GfF0cUL6aQQ=&amp;labelColor=black"
 title="Kerbal Space Program" alt="KSP version" /></a> <a
 href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
 title="CC BY-NC-SA 4.0"><img
@@ -22,11 +22,11 @@ title="GitHub Pages"><img
 src="https://github.com/zer0Kerbal/FuelTanksPlus/actions/workflows/pages/pages-build-deployment/badge.svg"
 title="GitHub IO" alt="GitHub Pages" /></a></p>
 <hr />
-<h1 id="version-2010-release---minor-fixes">Version 2.0.1.0-release -
-<code>&lt;Minor fixes&gt;</code></h1>
+<h1 id="version-2020-release---rcs-fixes">Version 2.0.2.0-release -
+<code>&lt;RCS fixes&gt;</code></h1>
 <ul>
-<li>2018-03-13</li>
-<li>For Kerbal Space Program 1.4.0</li>
+<li>2018-03-14</li>
+<li>For Kerbal Space Program 1.4.4</li>
 </ul>
 <h4 style="border:0.5px solid Tomato; background-color: #bada55; color: #FF0000; text-align:center">
 <b>DO A CLEAN INSTALL:</br> DELETE EXISTING INSTALLATION THEN RE-INSTALL</b></h4>
@@ -34,12 +34,11 @@ title="GitHub IO" alt="GitHub Pages" /></a></p>
 
 <h2 id="changes">Changes</h2>
 <ul>
-<li>Removed shrouds from nuclear tanks and added them to the
-color-switcher (just one color currently)</li>
-<li>Removed extraneous IFS/FS/B9 configs from the size-0 tanks.</li>
+<li>Rebalanced the smaller monopropellant tanks to match their stock
+counterparts.</li>
 <li>Co-Authored-By: NecroBones &lt;<a
 href="mailto:10134364+NecroBones@users.noreply.github.com">10134364+NecroBones@users.noreply.github.com</a></li>
-<li>closes #77 - 2.0.1 (2018-03-13) - Minor fixes</li>
+<li>closes #78 - 2.0.2 (2018-03-14) - RCS fixes</li>
 <li>updates #26 - Previous Releases</li>
 </ul>
 <hr />

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus-CHANGELOG.txt
@@ -1,3 +1,6 @@
+2.0.2 (2018-03-14) - RCS fixes
+ - Rebalanced the smaller monopropellant tanks to match their stock counterparts.
+
 2.0.1 (2018-03-13) - Minor fixes.
  - Removed shrouds from nuclear tanks and added them to the color-switcher (just one color currently)
  - Removed extraneous IFS/FS/B9 configs from the size-0 tanks.

--- a/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
+++ b/GameData/NecroBones/FuelTanksPlus/FuelTanksPlus.version
@@ -13,14 +13,14 @@
 	{
 		"MAJOR" : 2,
 		"MINOR" : 0,
-		"PATCH" : 1,
+		"PATCH" : 2,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 4,
-		"PATCH" : 0
+		"PATCH" : 4
 	},
 	"KSP_VERSION_MIN" :
 	{

--- a/GameData/NecroBones/FuelTanksPlus/RCS/TPmono0mL01875.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/RCS/TPmono0mL01875.cfg
@@ -34,7 +34,7 @@ PART
 	attachRules = 1,1,1,1,0
 
 	// --- standard part parameters ---
-	mass = 0.025
+	mass = 0.01
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -50,8 +50,8 @@ PART
 	RESOURCE
 	{
 		name = MonoPropellant
-		amount = 40
-		maxAmount = 40
+		amount = 10
+		maxAmount = 10
 	}
 
 }

--- a/GameData/NecroBones/FuelTanksPlus/RCS/TPmono1mL02850.cfg
+++ b/GameData/NecroBones/FuelTanksPlus/RCS/TPmono1mL02850.cfg
@@ -33,7 +33,7 @@ PART
 	attachRules = 1,0,1,1,0
 
 	// --- standard part parameters ---
-	mass = 0.075
+	mass = 0.04
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -49,8 +49,8 @@ PART
 	RESOURCE
 	{
 		name = MonoPropellant
-		amount = 125
-		maxAmount = 125
+		amount = 60
+		maxAmount = 60
 	}
 
 

--- a/docs/ReleaseNotes/2.0.2.0.md
+++ b/docs/ReleaseNotes/2.0.2.0.md
@@ -1,0 +1,134 @@
+---
+permalink: /2.0.2.0.html
+title: Release Notes v2.0.2.0
+description: Version Release Notes
+tags: FuelTanksPlus,release-notes,kerbal,ksp,zer0Kerbal,zedK
+layout: page
+---
+
+<!-- ReleaseLayout.md v1.3.1.3
+Fuel Tanks Plus (FTP)
+created: 11 Aug 2018
+updated: 30 Mar 2022 -->
+
+[![Fuel Tanks Plus Version][MOD:shd:stat]][MOD:forum] [![KSP version][KSP:shd:stat]][KSP:url]
+[![License][LIC:shd]][LIC:url]  ![AVC .version files][AVCVAL:shd]
+
+[![GitHub Pages][MOD:pages:shd]][MOD:pages]
+
+---
+
+# Version 2.0.2.0-release - `<RCS fixes>`
+
+* 2018-03-14
+* For Kerbal Space Program 1.4.4
+
+
+<h4 style="border:0.5px solid Tomato; background-color: #bada55; color: #FF0000; text-align:center">
+<b>DO A CLEAN INSTALL:</br> DELETE EXISTING INSTALLATION THEN RE-INSTALL</b></h4>
+<p style="border:0.5px solid Tomato; background-color: #bada55; color: #FF0000; text-align:center">Download from <a href="https://www.curseforge.com/kerbal/ksp-mods/FuelTanksPlus/files">CurseForge</a></p>
+
+## Changes
+
+* Rebalanced the smaller monopropellant tanks to match their stock counterparts.
+* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com
+* closes #78 - 2.0.2 (2018-03-14) - RCS fixes
+* updates #26 - Previous Releases
+
+--- 
+
+## See More
+
+* Changelog Summary for more details of changes : See [ChangeLog][MOD:chlog]  
+* Discussions and news on this mod : See [Discussions][MOD:discu] or [KSP Forums][MOD:forum]  
+* Known Issues for more details of feature requests and known issues : See [Known Issues][MOD:known]  
+* GitHub Pages : See [Pages][MOD:pages]
+
+## Localization
+
+>* ![English][EN] English
+>* ![简体中文][CN] Simplified Chinese (简体中文) - thank you @beefpatty
+>* ***your translation here***
+>
+> HELP WANTED - See the [README in the Localization folder][MOD:local] for instructions for adding or improving translations. [GitHub][GitHub:url] push is the best way to contribute. *Additions and corrections welcome!*
+
+---
+
+### How to support this and other great mods by [`zer0Kerbal`][zer0Kerbal]
+
+[![Support][PAYPAL:img]][PAYPAL:url] [![Patreon][PATREON:img]][PATREON:url] [![Github Sponsor][GSPONS:img]][GSPONS:url] [![Buy zer0Kerbal a snack][BMCC:img]][BMCC:url]
+
+---
+
+<div style="border:0.5px solid Tomato; background-color: #BADA55; color: #FF0000; text-align:center">
+<p><b>*red box below is a link to forum post on how to get support*</p>  
+<a href = "https://forum.kerbalspaceprogram.com/index.php?/topic/83212-*">
+  <p><img src = "https://i.postimg.cc/vHP6zmrw/image.png" alt="How to get support"></p></a>
+</br>
+<p>Be Kind: Lithobrake, not jakebrake! Keep your Module Manager up to date</p></div>
+
+---
+
+![][IMG:flg:0]
+
+---
+
+<!-- links -->
+[MOD:chlog]: https://github.com/zer0Kerbal/FuelTanksPlus/blob/master/changelog.md "Changelog"
+[MOD:discu]: https://github.com/zer0Kerbal/FuelTanksPlus/discussions "Discussions"
+[MOD:forum]: https://forum.kerbalspaceprogram.com/index.php?/topic/207702-* "Fuel Tanks Plus on the forums"
+[MOD:issue]: https://github.com/zer0Kerbal/FuelTanksPlus/issues "Issue Tracker"
+[MOD:known]: https://github.com/zer0Kerbal/FuelTanksPlus/wiki/Known-Issues "Known Issues"
+[MOD:licns]: https://github.com/zer0Kerbal/FuelTanksPlus/blob/master/LICENSE "Repo License"
+[MOD:local]:  https://github.com/zer0Kerbal/FuelTanksPlus/blob/master/GameData/FuelTanksPlus/Localization/readme.md "Localization"
+[MOD:pages]: https://zer0kerbal.github.io/FuelTanksPlus/ "GitHub Pages"
+[MOD:pages:shd]: https://github.com/zer0Kerbal/FuelTanksPlus/actions/workflows/pages/pages-build-deployment/badge.svg "GitHub IO"
+
+<!-- mod -->
+[MOD:shd:stat]: https://img.shields.io/badge/FuelTanksPlus%20(FTP)%20v-2.0.2.0--release-BADA55.svg?style=plastic&labelColor=darkgreen "2.0.2.0-release"
+
+[CRSFG:url]: https://www.curseforge.com/kerbal/ksp-mods/FuelTanksPlus/files "Curseforge"
+[GITHUB:url]: https://github.com/zer0Kerbal/FuelTanksPlus/ "GitHub"
+
+[KSP:url]: http://kerbalspaceprogram.com/ "Kerbal Space Program"
+[KSP:url]:   http://kerbalspaceprogram.com/ "Kerbal Space Program"  
+[KSP:shd:stat]: https://img.shields.io/badge/KSP-1.4.4-blue.svg?style=plastic&logo=data:image/webp;base64,UklGRpAGAABXRUJQVlA4TIQGAAAvH8AHEE0obNsGDakwXkT/Q4chj76jn1yYjSRjH6H+6xQqRUkkSc5ckHD+NUUVhx4+RNu2bTTl/3OTVhD6H8u6fF8dDYm40CK7N0CjAxK52rYtjfQRAvGNjbu7V+vuLp2fwhzA6gG4li6de+nuO+4uJBlkwoTA//90kENgtZZs27ZpO2Oufa5vbNsq2Sw6qaa9r3n/kZJTex/wSrFt27o62kuSJNuqrdTa1+/7uLu7uzQZAk0mRN/mAz2CAbi723vvy5WztxxIAAiw+dh2bdvWZJuT12y1bdu2bdu2bbs3AQABlsED+y50lDqLE4pf/Uxe8KO77HFes9hvxu1p3O2Q09LVg0NVjo7Z5U6AvwBSOfivKdQTujOnXNG8hzNhqYSMMHJ+MwWWyTSjNUoP1jWHp1ZNmgB8TMH3Tl33mvoVb8uIj3umyIJLsAmYoCIqUCVMCN5WrW78Qi+AkeaGOkWFk3QbRmIWHpIZSURXDxhJVlJiYZ6kLEgeEjIRCBmxebhCTWlTJNaXLystGysVToPOAFJJjqSPNOXftSVbXPQjxrzVaFNzXvBonWJlonIVTJabAfjZ0Jxufl5GPntEHKjB7PIXtg6eYHywJn3hTdijjXUain94KjfCfg1hm³AZRR4N16VMXBrsDVYDCjOIMmGFsAab8rdY7+kIw0BgtRgL1DKJeuNZdQ9f5RAGGfOQfZxexj7t37RkjNp4rPDIHOJVyPBF+XHKsnQk4SWRBl8Wot74WtkBqidQggbyj2vW1WEFG6JfUZ8UxhVzOmAUdKTYZ3yxR2QwIIAQdA9YgiRBZWyCguiOER9y9IauiyGqR0EayVLiEVwmXmF5+Z2jfohj8i1q8ybRahCBAXZBCBUqLgAACQFzp5M/o5wzCDcCJZEOF9EzggM7NEd18c1Q85gPBldtg6mwB1N+hzyTSFp5jWM+WpCRBEBAjIaUxJI80o3s6vDYJ7gNXuAUfOacvsLvLhNIMaMwh8GccsXjtuiK+wkxZ/kVdOCzoCeAOn+N7H1rU1YT35MgAWY9yD5wMWI7j7G976bSh8LxDx2jI3IJRAnJ+RQQIU7gABnLd3vKSyMAd71mq7HgV3AJ+Sxh5Bz5O0z/gbTiNT8DxQssrrv7Uyx9Y7q6BQVUoIGonF/FfoC/RqwVHlviCRSABDvLaCUfZlz1cNENn6adNTz+AF8v8KWQAFL+QMkpCthFkpvvq7+2/to6AIBhyvPdrUr3g1XwBEJPMeP/98SxWWvs3nHIhgNnsY1RWVyw+Guh5IZLgj9WzPi/iEk9gPPGLAni3aRlsqlGQ9jP4z9Q/s/xi3dw486abm6Bqi2l3qu9e9tQsdVMdG4zbVYqp5wJcBSA2W6sNmkwxuNk+nw3r4MFi/4EkTAhiRFk70jkqNDiWbDK65OLIn0s0wD/ucAp3XwVSsSNBAqjFUIXwFE0MihZQ6utQYV2oR+tShO7Ad6bswY3xd7qe0VrVxK9ZjueQy4TPnF8MCQGjoxSugSFgFMV4LiVwgsn/i+gXZ2FzplAduxnn0/OlW0uqf+M64MRPqzwrl+PnpKQSaXS49Ui7n2/ctFtHtAtiprzxq6WniwESvW5yUG1Xx6/8Hx8NKELwKZK15pV/EvXvm9ZMlx0aKUO98iUPaWvst/n8ZbOmkvGhcOQRWf5zj9dk9cfpad5oHN3Rns/wsuvy2puxz1Ziu96Q7/SOWoROzvNzFo5Z5+1BDej3OjQ/XymEkW9jr0em5g5SdX8VC2gf9xJb/RWCC5bIKWDgWcYf+K9Kje3zbQBh/F448wMLoICeUyJ330nXlPmawiRT/sblG4vWrbErgQaMzYbZcwbhSaNrwH+Tqa04jqrd3JZTvwbFxHFSVMAv5UZdEq+tQUupcis/5+MZNsxk9b8TPa7cMqdzzrh9FtD5v+vPACvJy7nDT69IP/Yx6EywGdTFsD5iU7bqkovJogzTjQm³iFTyp4jV4bjVKdcnv5/JrhokmpnGAIA4D/AXYCfVgoBXnrDkCqqCHRG529HeYB51Jy1z6nlW/gnVmzyxmVHxnQrxXxelcI0yN85udPl+//t2rzKzA+oluPTNjp6qY1PVduFVdo8ya+8E6p8KOZR+bLj6Vju9oi5dar0erTS8Z1x3/IITU3vyDRLiZWBZVH6CbqURTeLptD3pEPIR4W4QlHfTnRJzZBRJ8MlI8LmmEXLAdAxsqIYbSDGTt65GfF0cUL6aQQ=&labelColor=black "Kerbal Space Program"
+
+<!--- license -->
+[LIC:url]: https://creativecommons.org/licenses/by-nc-sa/4.0/ "CC BY-NC-SA 4.0"
+[LIC:log]: https://licensebuttons.net/i/l/by-nc-sa/transparent/33/66/99/76x22.png "CC BY-NC-SA 4.0"
+[LIC:shd]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-ef9421?labelColor=black&style=plastic&logoColor=ef9421&logo=creativecommons "CC BY-NC-SA 4.0"
+
+[AVCVAL:shd]: https://github.com/zer0Kerbal/FuelTanksPlus/workflows/Validate%20AVC%20.version%20files/badge.svg?style=plastic&labelColor=black
+
+[PAYPAL:img]: https://img.shields.io/badge/Buy%20me%20some%20-LFO-00457C?style=for-the-badge&logo=paypal&labelColor=FFDD00."PayPal"
+[PAYPAL:url]: https://www.paypal.com/donate?hosted_button_id=DC22YHMEJREKL "PayPal"
+[PATREON:img]: https://img.shields.io/badge/Patreon%20-be%20a%20Patron-FF424D?style=for-the-badge&logo=patreon "Patreon"
+[PATREON:url]: https://www.patreon.com/bePatron?u=23390503 "Patreon"
+[GSPONS:img]: https://img.shields.io/badge/Github%20-Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors "Github Sponsors"
+[GSPONS:url]: https://github.com/sponsors/zer0Kerbal "Github Sponsors"
+[BMCC:img]: https://img.shields.io/badge/Buy%20Me%20a%20-Snack!-FFDD00?style=for-the-badge&logo=buymeacoffee "Buy Me A Snack"
+[BMCC:url]: https://buymeacoffee.com/zer0Kerbal "Buy Me A Snack"
+[EN]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/American-flag-sm.png "American English"
+[BR]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Brazilian-flag-sm.png "Brasil"
+[CN]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Chinese-flag-sm.png "中文"
+[DE]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/German-flag-sm.png "Deutsch"
+[ES]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Spanish-flag-sm.png "Español"
+[FR]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/French-flag-sm.png "Français"
+[IT]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Italian-flag-sm.png "Italiano"
+[JA]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Japanese-flag-sm.png "日本語"
+[KO]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/South-Korean-flag-sm.png "한국어"
+[ME]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Mexican-flag-sm.png "Mexicano Español"
+[NL]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Dutch-flag-sm.png "Dutch"
+[NO]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Norwegian-flag-sm.png "Norsk"
+[PO]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Polish-flag-sm.png "Polski"
+[RU]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Russian-flag-sm.png "Русский"
+[SW]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Swedish-flag-sm.png "Svenska"
+[TW]: https://raw.githubusercontent.com/zer0Kerbal/zer0Kerbal/zed'K/Localization/img/Taiwanese-flag-sm.png "国语"
+
+[zer0Kerbal]: https://forum.kerbalspaceprogram.com/index.php?/profile/190933-*/ "zer0Kerbal"
+
+[IMG:flg:0]: https://via.placeholder.com/256x160png/ffffff/bada55?text=FTP "Fuel Tanks Plus Flag"
+[IMG:hero:0]: https://raw.githubusercontent.com/zer0Kerbal/FuelTanksPlus/master/img/HeroLogo_400x400.png "Fuel Tanks Plus"
+
+<!-- This File: CC BY-ND 3.0 Unported by zer0Kerbal -->

--- a/json/ksp.json
+++ b/json/ksp.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "KSP",
  "labelColor": "black",
- "message": "1.4.0",
+ "message": "1.4.4",
  "color": "66ccff",
  "style": "plastic"
 }

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Fuel Tanks Plus",
  "labelColor": "BADA55",
- "message": "2.0.1.0",
+ "message": "2.0.2.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## 2.0.2.0 (2018-03-14) - RCS fixes

* Rebalanced the smaller monopropellant tanks to match their stock counterparts.
* Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com
* closes #78 - 2.0.2 (2018-03-14) - RCS fixes
* updates #26 - Previous Releases

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>

---